### PR TITLE
Option -s was not recognized, probably because it was missing when passed

### DIFF
--- a/nosr.c
+++ b/nosr.c
@@ -405,7 +405,7 @@ static int parse_opts(int argc, char **argv)
 	/* defaults */
 	config.filefunc = search_metafile;
 
-	while((opt = getopt_long(argc, argv, "bghilR:ruv", opts, &opt_idx)) != -1) {
+	while((opt = getopt_long(argc, argv, "bghilR:rsuv", opts, &opt_idx)) != -1) {
 		switch(opt) {
 			case 'b':
 				config.binaries = 1;


### PR DESCRIPTION
Option -s was not recognized, probably because it was missing when passed to getopt_long().

$ nosr -s skel
nosr: invalid option -- 's'
$ nosr --s skel
extra/hylafax
