### PR TITLE
Makefile: Fix various build issues.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 OUT        = nosr
 VERSION    = 0.1
 CPPFLAGS  := -DVERSION=\"$(VERSION)\" -D_FILE_OFFSET_BITS=64 $(CPPFLAGS)
-CFLAGS    := --std=c99 -g -pedantic -Wall -Wextra -Werror $(CFLAGS) $(CPPFLAGS)
-LDFLAGS   := -larchive -lpcre -lcurl -pthread $(LDFLAGS)
+CFLAGS    := -std=c99 -g -pedantic -pthread -Wall -Wextra -Werror $(CFLAGS) $(CPPFLAGS)
+LDFLAGS   := ${CFLAGS} $(LDFLAGS) -larchive -lpcre -lcurl
 
 PREFIX    ?= /usr/local
 


### PR DESCRIPTION
Adjust Makefile so LTO works out of the box.
pthread_join(3) notes: Compile and link with -pthread.
--std is undocumented.
