### PR TITLE
Add -C option

### DIFF
--- a/src/pkgfile.c
+++ b/src/pkgfile.c
@@ -458,7 +458,7 @@ static void print_version(void) {
 
 static int parse_opts(int argc, char **argv) {
   int opt;
-  static const char *shortopts = "0bdghilqR:rsuVvwz::";
+  static const char *shortopts = "0bC:dghilqR:rsuVvwz::";
   static const struct option longopts[] = {
       {"binaries", no_argument, 0, 'b'},
       {"compress", optional_argument, 0, 'z'},


### PR DESCRIPTION
This was specified in the help and manual pages, however the argument
parser would not allow it to be specified, even when looking for it
later on.
