### PR TITLE
Add command_not_found_handler for fish shell

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,8 @@ shelldatadir=$(datarootdir)/doc/pkgfile
 
 dist_shelldata_DATA = \
 	extra/command-not-found.bash \
-	extra/command-not-found.zsh
+	extra/command-not-found.zsh \
+	extra/command-not-found.fish
 
 EXTRA_DIST = \
 	README.pod \

--- a/README.pod
+++ b/README.pod
@@ -147,7 +147,9 @@ Storage location for metadata.
 
 =item I</usr/share/doc/pkgfile/command-not-found.zsh>
 
-zsh and bash compatible functions which can be included in shell initalization
+=item I</usr/share/doc/pkgfile/command-not-found.fish>
+
+zsh, bash and fish compatible functions which can be included in shell initalization
 to run pkgfile when an executed command is not found.
 
 =back

--- a/extra/command-not-found.fish
+++ b/extra/command-not-found.fish
@@ -1,0 +1,10 @@
+function command_not_found_handler --on-event fish_command_not_found
+    set cmd $argv
+
+    if set pkgs (pkgfile -bv -- "$cmd" 2>/dev/null)
+        printf '%s may be found in the following packages:\n' "$cmd"
+        for pkg in $pkgs
+            printf '  %s\n' "$pkg"
+        end
+    end
+end


### PR DESCRIPTION
I tried to keep it similar to the other scripts. But I didn't return anything because fish outputs `fish: Unknown command 'command-name'` and returns `127` in the end.
