### PR TITLE
Added option to install package if only one package is found.

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -150,7 +150,10 @@ Storage location for metadata.
 =item I</usr/share/doc/pkgfile/command-not-found.fish>
 
 zsh, bash and fish compatible functions which can be included in shell initalization
-to run pkgfile when an executed command is not found.
+to run pkgfile when an executed command is not found. 
+
+If the environment variable PKGFILE_PROMPT_INSTALL_MISSING is set, and only one
+package is found, a prompt to install the package will be shown.
 
 =back
 

--- a/extra/command-not-found.bash
+++ b/extra/command-not-found.bash
@@ -5,6 +5,18 @@ command_not_found_handle () {
   set +o verbose
 
   mapfile -t pkgs < <(pkgfile -bv -- "$cmd" 2>/dev/null)
+
+  if [[ ${#pkgs[*]} -eq 1 && -n $PKGFILE_PROMPT_INSTALL_MISSING ]]; then
+    local pkg=${pkgs[0]%% *}
+    local response
+
+    read -r -p "Install $pkg? [Y/n] " response
+    [[ -z $response || $response = [Yy] ]] || return 0
+    printf '\n'
+    sudo pacman -S --noconfirm -- "$pkg"
+    return 0
+  fi
+
   if (( ${#pkgs[*]} )); then
     printf '%s may be found in the following packages:\n' "$cmd"
     printf '  %s\n' "${pkgs[@]}"


### PR DESCRIPTION
I've always thought it would be handy for pkgfile to prompt you to install the package that it found for you. So this gives you the following output: 

    ~ > ifconfig
    Install core/net-tools? [Y/n] n
    ~ > ifconfig
    Install core/net-tools? [Y/n] y
    
    [sudo] password for owg1: 
    resolving dependencies...
    looking for conflicting packages...
    
    Packages (1) net-tools-1.60.20160710git-1
    
    Total Installed Size:  0.46 MiB
    
    :: Proceed with installation? [Y/n] 
    (1/1) checking keys in keyring                                          [########################################] 100%
    (1/1) checking package integrity                                        [########################################] 100%
    (1/1) loading package files                                             [########################################] 100%
    (1/1) checking for file conflicts                                       [########################################] 100%
    (1/1) checking available disk space                                     [########################################] 100%
    :: Processing package changes...
    (1/1) installing net-tools                                              [########################################] 100%
    :: Running post-transaction hooks...
    (1/1) Updating manpage index...
    
