### PR TITLE
Add command not found message removed in zsh 5.3

### DIFF
--- a/extra/command-not-found.zsh
+++ b/extra/command-not-found.zsh
@@ -8,5 +8,6 @@ command_not_found_handler() {
     return 0
   fi
 
+  printf 'zsh: command not found: %s\n' "$cmd"
   return 127
 }


### PR DESCRIPTION
Closes #28.