### PR TITLE
Print zsh's command not found message to stderr

### DIFF
--- a/extra/command-not-found.zsh
+++ b/extra/command-not-found.zsh
@@ -8,6 +8,6 @@ command_not_found_handler() {
     return 0
   fi
 
-  printf 'zsh: command not found: %s\n' "$cmd"
+  printf 'zsh: command not found: %s\n' "$cmd" 1>&2
   return 127
 }


### PR DESCRIPTION
As suggested by @matiasgagliano