### PR TITLE
Start systemd service after network is online

### DIFF
--- a/systemd/pkgfile-update.service
+++ b/systemd/pkgfile-update.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=pkgfile database update
 RequiresMountsFor=/var/cache/pkgfile
+After=network-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
As proposed in #19 by @medhefgo.

This way it is more likely that the system is connected to the Internet when pkgfile wants to update the database. I have abstained from adding a `Wants=` line as I believe we should not pull in `network-online.target` too liberally.