### PR TITLE
Include path in "short" result format.

### DIFF
--- a/src/result.c
+++ b/src/result.c
@@ -157,7 +157,7 @@ static void result_print_long(struct result_t *result, int prefixlen,
 
 static void result_print_short(struct result_t *result, char eol) {
   for (size_t i = 0; i < result->size; ++i) {
-    printf("%s%c", result->lines[i]->prefix, eol);
+    printf("%s\t%s%c", result->lines[i]->prefix, result->lines[i]->entry, eol);
   }
 }
 


### PR DESCRIPTION
The documentation for `-w`/`--raw` ("Avoid justification of 2 column output.") suggests that it skips padding output fields with extra whitespace to align them in columns. But its current implementation skips printing the second column altogether, resulting in less-than-useful output.

### Current Behavior
Compared to without `-w`, excludes path entirely:
```
$ pkgfile -l -g 'pkg*' -w
core/pkgconf
core/pkgconf
[...]
extra/pkgfile
extra/pkgfile
[...]
extra/pkgstats
extra/pkgstats
[...]
community/pkgdiff
community/pkgdiff
[...]
```

### New Behavior
Compared to without `-w`, avoids column-justification:
```
$ pkgfile -l -g 'pkg*' -w
core/pkgconf	/usr/
core/pkgconf	/usr/bin/
core/pkgconf	/usr/bin/i686-pc-linux-gnu-pkg-config
[...]
extra/pkgfile	/usr/
extra/pkgfile	/usr/bin/
extra/pkgfile	/usr/bin/pkgfile
[...]
extra/pkgstats	/usr/
extra/pkgstats	/usr/bin/
extra/pkgstats	/usr/bin/pkgstats
[...]
community/pkgdiff	/usr/
community/pkgdiff	/usr/bin/
community/pkgdiff	/usr/bin/pkgdiff
[...]
```