### PR TITLE
`command_not_found_handle(r)`: Print info to STDERR instead of STDOUT

### DIFF
--- a/extra/command-not-found.bash
+++ b/extra/command-not-found.bash
@@ -21,8 +21,8 @@ command_not_found_handle () {
     printf '%s may be found in the following packages:\n' "$cmd"
     printf '  %s\n' "${pkgs[@]}"
   else
-    printf "bash: %s: command not found\n" "$cmd" >&2
-  fi
+    printf "bash: %s: command not found\n" "$cmd"
+  fi >&2
 
   return 127
 }

--- a/extra/command-not-found.zsh
+++ b/extra/command-not-found.zsh
@@ -6,8 +6,8 @@ command_not_found_handler() {
     printf '%s may be found in the following packages:\n' "$cmd"
     printf '  %s\n' $pkgs[@]
   else
-    printf 'zsh: command not found: %s\n' "$cmd" 1>&2
-  fi
+    printf 'zsh: command not found: %s\n' "$cmd"
+  fi 1>&2
 
   return 127
 }


### PR DESCRIPTION
Otherwise the handlers confuse other functionality expecting output
from the actual commands. One example where I was bitten by this:

When zsh tries to complete network interfaces (e.g. from the `_ip`
completion function), it ends up (via `_find_net_interfaces`) doing
this:

``` shell
ifconfig -a 2>/dev/null | sed -n 's/^\([^        :]*\).*/\1/p'
```

... which, with ifconfig not installed and the current version of
the handler installed, prints "ifconfig\n\n" to STDOUT and is then
recognized as valid command output, preventing further interface
lookup.

This change fixes the problem for zsh and bash (tested). I found fish
too fishy to be confident enough to make the change there, too.