### PR TITLE
Make systemd unit depend on network-online.target

### DIFF
--- a/systemd/pkgfile-update.service.in
+++ b/systemd/pkgfile-update.service.in
@@ -1,6 +1,8 @@
 [Unit]
 Description=pkgfile database update
 RequiresMountsFor=@DEFAULT_CACHEPATH@
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The unit would just fail if network hasn't been configured yet, which can happen if the timer unit happens to trigger early enough at boot.