### PR TITLE
Make update timer wait for network connection

### DIFF
--- a/systemd/pkgfile-update.timer
+++ b/systemd/pkgfile-update.timer
@@ -1,5 +1,7 @@
 [Unit]
 Description=pkgfile database update timer
+Wants=network-online.target
+After=network-online.target
 
 [Timer]
 OnCalendar=daily


### PR DESCRIPTION
When booting my laptop with this service enabled, it ends up degraded with this unit file. The error usually includes having no internet connection, so waiting for the connection to be available seems to me to be a sensible default.