### PR TITLE
pkgfile-update.service: Add After=nss-lookup.target

### DIFF
--- a/systemd/pkgfile-update.service.in
+++ b/systemd/pkgfile-update.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=pkgfile database update
 RequiresMountsFor=@DEFAULT_CACHEPATH@
-After=network-online.target
+After=network-online.target nss-lookup.target
 Wants=network-online.target
 
 [Service]


### PR DESCRIPTION
This is a follow-up of https://github.com/falconindy/pkgfile/pull/51 ("Make systemd unit depend on network-online.target") that enhances the unit file with `After=nss-lookup.target`.

This is needed as per https://wiki.archlinux.org/title/systemd#Running_services_after_the_network_is_up:

> From systemd.special(7):
> "All services for which the availability of full host/network name resolution
> is essential should be ordered after this target, but not pull it in."