### PR TITLE
command-not-found: fish: replace event with native function

### DIFF
--- a/extra/command-not-found.fish
+++ b/extra/command-not-found.fish
@@ -1,4 +1,4 @@
-function command_not_found_handler --on-event fish_command_not_found
+function fish_command_not_found
     set cmd $argv
 
     if set pkgs (pkgfile -bv -- "$cmd" 2>/dev/null)


### PR DESCRIPTION
Since fish 3.2 the native way is to define `fish_command_not_found`
instead of using the event:

> This command was introduced in fish 3.2.0. Previous versions of fish
used the "fish_command_not_found" event instead.