### PR TITLE
Fix build failure (missing include of <optional>)

### DIFF
--- a/src/pkgfile.hh
+++ b/src/pkgfile.hh
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <map>
+#include <optional>
 
 #include "archive_reader.hh"
 #include "filter.hh"


### PR DESCRIPTION
E.g.:
../src/pkgfile.hh:76:8: error: ‘optional’ in namespace ‘std’ does not name a template type
   76 |   std::optional<pkgfile::Result> ProcessRepo(const std::filesystem::path repo,
      |        ^~~~~~~~
../src/pkgfile.hh:9:1: note: ‘std::optional’ is defined in header ‘<optional>’; did you forget to ‘#include <optional>’?