### PR TITLE
Migrate to PCRE2

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,5 +1,5 @@
 Requirements:
   - libcurl
   - libarchive
-  - pcre
+  - pcre2
   - pthreads

--- a/README.pod
+++ b/README.pod
@@ -63,7 +63,7 @@ Disable case sensitivity in matching.
 
 =item B<-r>, B<--regex>
 
-Enable regular expression matching. See B<pcre>(3).
+Enable regular expression matching. See B<pcre2>(3).
 
 =item B<-R> I<REPO>, B<--repo=>I<REPO>
 
@@ -172,7 +172,7 @@ can be enabled with:
 
 =head1 SEE ALSO
 
-B<repo-add>(8), B<pcre>(3), B<glob>(7), B<pacman.conf>(5)
+B<repo-add>(8), B<pcre2>(3), B<glob>(7), B<pacman.conf>(5)
 
 =head1 AUTHOR
 

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@ configure_file(
 
 add_project_arguments('-include', 'config.h', language : 'c')
 
-libpcre = dependency('libpcre', version : '>= 8.30')
+libpcre2 = dependency('libpcre2-8', version : '>= 10')
 libarchive = dependency('libarchive', version : '>= 3.2.0')
 libcurl = dependency('libcurl')
 pthreads = dependency('threads')
@@ -59,7 +59,7 @@ run_target(
 executable(
   'pkgfile',
   pkgfile_sources,
-  dependencies : [libpcre, libarchive, libcurl, pthreads],
+  dependencies : [libpcre2, libarchive, libcurl, pthreads],
   install : true)
 
 man = custom_target(

--- a/src/match.c
+++ b/src/match.c
@@ -12,13 +12,15 @@ int match_glob(const filterpattern_t *pattern, const char *line, int UNUSED len,
 
 int match_regex(const filterpattern_t *pattern, const char *line, int len,
                 int UNUSED flags) {
-  return pcre_exec(pattern->re.re, pattern->re.re_extra, line, len, 0,
-                   PCRE_NO_UTF16_CHECK, NULL, 0) < 0;
+  pcre2_match_data *match_data = pcre2_match_data_create_from_pattern(pattern->re.re, NULL);
+  int result = pcre2_match(pattern->re.re, (PCRE2_SPTR)line, len, 0,
+                   PCRE2_NO_UTF_CHECK, match_data, 0);
+  pcre2_match_data_free(match_data);
+  return result < 0;
 }
 
 void free_regex(filterpattern_t *pattern) {
-  pcre_free(pattern->re.re);
-  pcre_free_study(pattern->re.re_extra);
+  pcre2_code_free(pattern->re.re);
 }
 
 int match_exact_basename(const filterpattern_t *pattern, const char *line,

--- a/src/pkgfile.c
+++ b/src/pkgfile.c
@@ -355,19 +355,12 @@ cleanup:
 static int compile_pcre_expr(struct pcre_data *re, const char *preg,
                              int flags) {
   const char *err;
-  int err_offset;
+  size_t err_offset;
 
-  re->re = pcre_compile(preg, flags, &err, &err_offset, NULL);
+  re->re = pcre2_compile((PCRE2_SPTR)preg, PCRE2_ZERO_TERMINATED, flags, &err, &err_offset, NULL);
   if (!re->re) {
     fprintf(stderr, "error: failed to compile regex at char %d: %s\n",
             err_offset, err);
-    return 1;
-  }
-
-  re->re_extra = pcre_study(re->re, PCRE_STUDY_JIT_COMPILE, &err);
-  if (err) {
-    fprintf(stderr, "error: failed to study regex: %s\n", err);
-    pcre_free(re->re);
     return 1;
   }
 
@@ -621,7 +614,7 @@ static int filter_setup(char *arg) {
       config.filterfunc = match_glob;
       break;
     case FILTER_REGEX:
-      config.matchflags = config.icase ? PCRE_CASELESS : 0;
+      config.matchflags = config.icase ? PCRE2_CASELESS : 0;
       config.filterfunc = match_regex;
       config.filterfree = free_regex;
       return compile_pcre_expr(&config.filter.re, arg, config.matchflags);

--- a/src/pkgfile.h
+++ b/src/pkgfile.h
@@ -6,7 +6,8 @@
 #include <archive.h>
 #include <archive_entry.h>
 
-#include <pcre.h>
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
 
 #include "result.h"
 
@@ -31,8 +32,7 @@ typedef enum _filterstyle_t {
 
 typedef union _filterpattern_t {
   struct pcre_data {
-    pcre *re;
-    pcre_extra *re_extra;
+    pcre2_code *re;
   } re;
   struct glob_data {
     char *glob;


### PR DESCRIPTION
I followed this issue for guidance: https://github.com/PCRE2Project/pcre2/issues/51

pcre2 approach seems a bit slower, likely because it's allocating those match_data structs for every check. I tried to allocate it once during init but it seemed to segfault :sweat_smile: 