### PR TITLE
db: Support cachedir paths containing dots

### DIFF
--- a/src/db.cc
+++ b/src/db.cc
@@ -80,7 +80,7 @@ std::unique_ptr<Database> Database::Open(std::string_view dbpath,
   Repos repos;
   for (const auto& entry : fs::directory_iterator(dbpath, ec)) {
     const fs::path& pathname = entry.path();
-    if (!entry.is_regular_file() || !FilenameHasRepoSuffix(pathname.native())) {
+    if (!entry.is_regular_file() || !FilenameHasRepoSuffix(pathname.filename().native())) {
       continue;
     }
 


### PR DESCRIPTION
Current implementation counts dots in the entire path, which disallows having cachedir under a path containig any dots. To fix this we can call FilenameHasRepoSuffix with only the filename part of the path.