### PR TITLE
pkgfile-update: use systemd path unit to trigger database update

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ conf.set_quoted('PACKAGE_NAME', meson.project_name())
 conf.set_quoted('PACKAGE_VERSION', meson.project_version())
 conf.set_quoted('DEFAULT_CACHEPATH', get_option('cachedir'))
 conf.set_quoted('DEFAULT_PACMAN_CONF', '/etc/pacman.conf')
+conf.set('DEFAULT_DBPATH', get_option('dbpath'))
 
 cpp = meson.get_compiler('cpp')
 
@@ -141,6 +142,13 @@ if get_option('systemd_units')
     configure_file(
         input: 'systemd/pkgfile-update.service.in',
         output: 'pkgfile-update.service',
+        configuration: conf,
+        install_dir: systemunitdir,
+    )
+
+    configure_file(
+        input: 'systemd/pkgfile-update.path.in',
+        output: 'pkgfile-update.path',
         configuration: conf,
         install_dir: systemunitdir,
     )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,6 +3,11 @@ option('cachedir',
        value : '/var/cache/pkgfile',
        description : 'default directory to store pkgfile data')
 
+option('dbpath',
+       type : 'string',
+       value : '/var/lib/pacman',
+       description : 'default location of the toplevel database directory')
+
 option('systemd_units',
        type : 'boolean',
        value : true,

--- a/systemd/pkgfile-update.path.in
+++ b/systemd/pkgfile-update.path.in
@@ -1,0 +1,8 @@
+[Unit]
+Description=pkgfile datebase update path trigger
+
+[Path]
+PathChanged=@DEFAULT_DBPATH@/sync
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/pkgfile-update.service.in
+++ b/systemd/pkgfile-update.service.in
@@ -5,12 +5,17 @@ After=network-online.target nss-lookup.target
 Wants=network-online.target
 
 [Service]
-Type=oneshot
+Type=exec
+ExecCondition=/usr/bin/pidwait -xu0 pacman
 ExecStart=/usr/bin/pkgfile -u
+TimeoutStartSec=infinity
+RuntimeMaxSec=300
 Nice=19
 StandardOutput=null
 StandardError=journal
 PrivateTmp=yes
 PrivateDevices=yes
+ProtectSystem=full
+ProtectHome=yes
 CapabilityBoundingSet=
 NoNewPrivileges=yes


### PR DESCRIPTION
The systemd path unit will trigger the modified pkgfile-update.service unit when the ALPM sync database files gets modified (e.g. during `pacman -Sy`), and the new service will wait until the pacman process that triggered the update exit, then do the update of the pkgfile database files. The `pidwait` command is from the package `procps-ng`, which is a direct dependency of the `base` package, so all Arch Linux installations should have it.

The `TimeoutStartSec=infinity` option will allow the service to wait for the pacman process indefinitely, otherwise by default the service will be terminated by systemd in 90 seconds.

The `RuntimeMaxSec=300` option will limit the actual execution time of the `pkgfile -u` command to 300 seconds to prevent it from running forever.

The `ProtectSystem` and `ProtectHome` options will further enhance the protection of the filesystem.

The build time option `dbpath` will allow builds to have a different ALPM DB path as seen in the [`pacman.conf`](https://man.archlinux.org/man/core/pacman/pacman.conf.5.en#OPTIONS:~:text=DBPath%20%3D%20%2Fpath%2Fto%2Fdb%2Fdir) configuration, and the `PathChanged` path unit option doesn't require the value to be quoted, so `set()` is used in the `meson.build` configuration instead of `set_quoted()`.